### PR TITLE
added dynamodb into backend

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,5 +17,10 @@ terraform {
     bucket = "datanextapps"
     key    = "terraform/dev/terraform_dev.tfstate"
     region = "us-east-1"
+
+    # while working in team locking is important
+    # use your table name
+    dynamodb_table = "terraform_remote_locks"
+    encrypt        = true
   }
 }


### PR DESCRIPTION
While working with terraform in a team, we must avoid write conflicts hence we can overcome this problem using locking mechanism which is enable by dynamodb. 